### PR TITLE
Improve error handling for Hadoop qat codec

### DIFF
--- a/hadoop_qat_wrapper/src/main/java/org/apache/hadoop/util/QatNativeCodeLoader.java
+++ b/hadoop_qat_wrapper/src/main/java/org/apache/hadoop/util/QatNativeCodeLoader.java
@@ -48,12 +48,8 @@ public class QatNativeCodeLoader {
       LOG.debug("Loaded the native-qat library");
       nativeCodeLoaded = true;
     } catch (Throwable t) {
-      // Ignore failure to load
-      if(LOG.isDebugEnabled()) {
-        LOG.debug("Failed to load native-qat with error: " + t);
-        LOG.debug("java.library.path=" +
-            System.getProperty("java.library.path"));
-      }
+      LOG.error("Failed to load native-qat with error: ", t);
+      LOG.error("java.library.path=" + System.getProperty("java.library.path"));
     }
 
     if (!nativeCodeLoaded) {

--- a/hadoop_qat_wrapper/src/main/native/QatCompressor.c
+++ b/hadoop_qat_wrapper/src/main/native/QatCompressor.c
@@ -64,7 +64,7 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_io_compress_qat_QatCompressor_init
   if (!libqatzip) {
     char msg[1000];
     snprintf(msg, 1000, "%s (%s)!", "Cannot load " HADOOP_QAT_LIBRARY, dlerror());
-    THROW(env, "java/lang/UnsatisfiedLinkError1", msg);
+    THROW(env, "java/lang/UnsatisfiedLinkError", msg);
     return;
   }
 #endif


### PR DESCRIPTION
Improved logs for failure cases,

1. Logs below message when libqatcodec.so is not available.

```
2019-07-17 10:39:53,775 INFO [main] org.apache.hadoop.util.QatNativeCodeLoader: Failed to load native-qat with error:
java.lang.UnsatisfiedLinkError: no qatcodec in java.library.path
```

2. Logs below message when libqatzip.so is not available.

`java.lang.UnsatisfiedLinkError: Cannot load libqatzip.so (libqatzip.so: cannot open shared object file: No such file or directory)!
`