### PR TITLE
Added support for usage of qzMalloc for native buffer allocation in Spark

### DIFF
--- a/spark_qat_wrapper/src/main/java/com/intel/qat/jni/QatCodecJNI.java
+++ b/spark_qat_wrapper/src/main/java/com/intel/qat/jni/QatCodecJNI.java
@@ -41,5 +41,7 @@ public enum QatCodecJNI {
   public static native int decompress(long context, ByteBuffer srcBuffer, int srcOff, int srcLen,
           ByteBuffer destBuffer, int destOff, int destLen);
   public static native String getLibraryName(int codec);
+  public static native Object qzMalloc(long capacity, boolean numa,
+      boolean forcePinned);
 }
 

--- a/spark_qat_wrapper/src/main/java/com/intel/qat/spark/QatCodecBlockInputStream.java
+++ b/spark_qat_wrapper/src/main/java/com/intel/qat/spark/QatCodecBlockInputStream.java
@@ -56,6 +56,11 @@ public final class QatCodecBlockInputStream extends FilterInputStream {
    *                          must be >= 32k
    */
   public QatCodecBlockInputStream(InputStream in, int blockSize, boolean useNativeBuffer) {
+    this(in, blockSize, useNativeBuffer, true, true, false);
+  }
+
+  public QatCodecBlockInputStream(InputStream in, int blockSize,
+      boolean useNativeBuffer, boolean useQzMalloc, boolean useForcePinned, boolean useNuma) {
     super(in);
     this.uncompressedBlockSize = blockSize;
     this.compressedBlockSize = blockSize * 3 / 2;
@@ -64,10 +69,12 @@ public final class QatCodecBlockInputStream extends FilterInputStream {
     this.compressedBufferAllocator = CachedBufferAllocator
         .getBufferAllocatorFactory().getBufferAllocator(compressedBlockSize);
     this.uncompressedBuffer = uncompressedBufferAllocator
-        .allocateDirectByteBuffer(useNativeBuffer, uncompressedBlockSize, 64);
-    this.compressedBuffer = compressedBufferAllocator
-        .allocateDirectByteBuffer(useNativeBuffer, compressedBlockSize, 64);
-    
+        .allocateDirectByteBuffer(useNativeBuffer, uncompressedBlockSize, 64,
+            useQzMalloc, useForcePinned, useNuma);
+    this.compressedBuffer = compressedBufferAllocator.allocateDirectByteBuffer(
+        useNativeBuffer, compressedBlockSize, 64, useQzMalloc, useForcePinned,
+        useNuma);
+
     if(null!=uncompressedBuffer){
       uncompressedBuffer.clear();
     }

--- a/spark_qat_wrapper/src/main/java/com/intel/qat/spark/QatCodecBlockOutputStream.java
+++ b/spark_qat_wrapper/src/main/java/com/intel/qat/spark/QatCodecBlockOutputStream.java
@@ -64,8 +64,14 @@ public final class QatCodecBlockOutputStream extends FilterOutputStream {
    * @param blockSize   the maximum number of bytes to try to compress at once,
    *                    must be >= 32 K
    */
-  public QatCodecBlockOutputStream(OutputStream out,
-          int level, int blockSize, boolean useNativeBuffer) {
+  public QatCodecBlockOutputStream(OutputStream out, int level, int blockSize,
+      boolean useNativeBuffer) {
+    this(out, level, blockSize, useNativeBuffer, true, true, false);
+  }
+
+  public QatCodecBlockOutputStream(OutputStream out, int level, int blockSize,
+      boolean useNativeBuffer, boolean useQzMalloc, boolean useForcePinned,
+      boolean useNuma) {
     super(out);
     this.level = level;
     this.uncompressedBlockSize = blockSize;
@@ -74,10 +80,12 @@ public final class QatCodecBlockOutputStream extends FilterOutputStream {
             getBufferAllocatorFactory().getBufferAllocator(uncompressedBlockSize);
     this.compressedBufferAllocator = CachedBufferAllocator.
             getBufferAllocatorFactory().getBufferAllocator(compressedBlockSize);
-    this.uncompressedBuffer = uncompressedBufferAllocator.
-            allocateDirectByteBuffer(useNativeBuffer, uncompressedBlockSize, 64);
-    this.compressedBuffer = compressedBufferAllocator.
-            allocateDirectByteBuffer(useNativeBuffer, compressedBlockSize, 64);
+    this.uncompressedBuffer = uncompressedBufferAllocator
+        .allocateDirectByteBuffer(useNativeBuffer, uncompressedBlockSize, 64,
+            useQzMalloc, useForcePinned, useNuma);
+    this.compressedBuffer = compressedBufferAllocator.allocateDirectByteBuffer(
+        useNativeBuffer, compressedBlockSize, 64, useQzMalloc, useForcePinned,
+        useNuma);
     if(uncompressedBuffer != null) {
       uncompressedBuffer.clear();
     }

--- a/spark_qat_wrapper/src/main/java/com/intel/qat/util/buffer/BufferAllocator.java
+++ b/spark_qat_wrapper/src/main/java/com/intel/qat/util/buffer/BufferAllocator.java
@@ -25,7 +25,8 @@ import java.nio.ByteBuffer;
 public interface BufferAllocator
 {
 
-  public ByteBuffer allocateDirectByteBuffer(boolean useNativeBuffer, int size, int align);
+  public ByteBuffer allocateDirectByteBuffer(boolean useNativeBuffer, int size,
+      int align, boolean useQzMalloc, boolean useForcePinned, boolean useNuma);
 
   public void releaseDirectByteBuffer(ByteBuffer buffer);
 

--- a/spark_qat_wrapper/src/main/native/QatCodecJNI.c
+++ b/spark_qat_wrapper/src/main/native/QatCodecJNI.c
@@ -285,3 +285,9 @@ Java_com_intel_qat_jni_QatCodecJNI_decompress(
 
     return uncompressed_size;
 }
+
+JNIEXPORT jobject JNICALL
+Java_com_intel_qat_jni_QatCodecJNI_qzMalloc(JNIEnv *env,
+ jobject obj, jlong capacity, jboolean numa, jboolean force_pinned){
+  return (*env)->NewDirectByteBuffer(env, qzMalloc(capacity, numa, force_pinned), capacity);
+}

--- a/spark_qat_wrapper/src/main/scala/org/apache/spark/io/QatCompressionCodec.scala
+++ b/spark_qat_wrapper/src/main/scala/org/apache/spark/io/QatCompressionCodec.scala
@@ -43,7 +43,14 @@ class QatCompressionCodec(conf: SparkConf) extends CompressionCodec {
         "1024k").toInt
     val useNativeBuffer = conf.getBoolean("spark.io.compression.qat.useNativeBuffer",
         false)
-    new QatCodecBlockOutputStream(s, level, bufferSize, useNativeBuffer)
+    val useQzMalloc = conf.getBoolean("spark.io.compression.qat.native-bb.useQzMalloc",
+        true)
+    val useForcePinned = conf.getBoolean("spark.io.compression.qat.native-bb.useForcePinned",
+        true)
+    val useNuma = conf.getBoolean("spark.io.compression.qat.native-bb.useNuma",
+        false)
+    new QatCodecBlockOutputStream(s, level, bufferSize, useNativeBuffer, useQzMalloc,
+        useForcePinned, useNuma)
   }
 
   override def compressedInputStream(s: InputStream): InputStream = {
@@ -51,6 +58,13 @@ class QatCompressionCodec(conf: SparkConf) extends CompressionCodec {
         "1024k").toInt
     val useNativeBuffer = conf.getBoolean("spark.io.compression.qat.useNativeBuffer",
         false)
-    new QatCodecBlockInputStream(s, bufferSize, useNativeBuffer)
+    val useQzMalloc = conf.getBoolean("spark.io.compression.qat.native-bb.useQzMalloc",
+        true)
+    val useForcePinned = conf.getBoolean("spark.io.compression.qat.native-bb.useForcePinned",
+        true)
+    val useNuma = conf.getBoolean("spark.io.compression.qat.native-bb.useNuma",
+        false)
+    new QatCodecBlockInputStream(s, bufferSize, useNativeBuffer, useQzMalloc, useForcePinned,
+        useNuma)
   }
 }


### PR DESCRIPTION
This PR adds the support for using the qzMalloc for native buffer allocation in Spark. As part of PR, these below configurations added for qzMalloc allocation parameters, and these configurations only applicable when `spark.io.compression.qat.useNativeBuffer=true`.

`spark.io.compression.qat.native-bb.useQzMalloc` - Whether to use qzMalloc for native buffer allocation or not. Default value is `true`
`spark.io.compression.qat.native-bb.useForcePinned` - Whether to allocate continuous memory for qzMalloc. Default value is `true`
`spark.io.compression.qat.native-bb.useNuma` - Whether to allocate memory from NUMA node for qzMalloc. Default value is `false`.


